### PR TITLE
Minor bug fixes

### DIFF
--- a/scripts/dtp-bd-exporter.py
+++ b/scripts/dtp-bd-exporter.py
@@ -171,7 +171,7 @@ CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
     [
         "DEBUG",
         "INFO",
-        "NOTSET"
+        "CRITICAL"
     ]), help="Select log level to output", default="INFO", show_default=True)
 @click.option('--log_out', is_flag=True,
               help="Redirect log info to file", default=False, show_default=True)

--- a/scripts/dtp-feedback-hists.py
+++ b/scripts/dtp-feedback-hists.py
@@ -194,7 +194,7 @@ def cli(file_path: str, hardware_map_file: str, input_type: str, tr_num, interac
             if tr not in trl:
                 raise IndexError(f"{tr} does not exists!")
             try:
-                entries.append(rdm.load_entry(file_path, tr))
+                entries.append(rdm.load_entry(f, tr))
             except:
                 rich.print(f"Error when trying to open record {tr}!")
                 pass

--- a/scripts/dtp-feedback-plots.py
+++ b/scripts/dtp-feedback-plots.py
@@ -417,7 +417,7 @@ def cli(file_path: str, hardware_map_file: str, input_type: str, tr_num, interac
             if tr not in trl:
                 raise IndexError(f"{tr} does not exists!")
             try:
-                entries.append(rdm.load_entry(file_path, tr))
+                entries.append(rdm.load_entry(f, tr))
             except:
                 rich.print(f"Error when trying to open record {tr}!")
                 pass

--- a/src/fwtp_unpack_utils.cpp
+++ b/src/fwtp_unpack_utils.cpp
@@ -153,6 +153,7 @@ std::vector<FWTP> unpack_fwtps(void *buf, size_t n_blocks, bool safe_mode){
             tp_offset != 0
           ) {
             fmt::print("Found TP trailer at the wrong distance from previous one: {} delta={} (tp_offset={})\n", i, delta, tp_offset);
+            tp_offset = i+words_per_block-marker_offset;
             continue;
         }
 


### PR DESCRIPTION
- Solved bug dealing with relative paths in TR hist/plot scripts.
- Fixed issue in binary TP unpacker when a malformed TP frame is found, updating the offset.
- Minor fix to the log level options in binary exporter.